### PR TITLE
Create SQL Image & Persistent Volume Claim

### DIFF
--- a/local-persistentvolumeclaim.yml
+++ b/local-persistentvolumeclaim.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mssql-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Mi

--- a/mssql-makers-depl.yml
+++ b/mssql-makers-depl.yml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mssql-makers-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mssql
+  template:
+    metadata:
+      labels:
+        app: mssql
+    spec:
+      containers:
+        - name: mssql
+          image: mcr.microsoft.com/azure-sql-edge:latest
+          ports:
+            - containerPort: 1433
+          env:
+          - name: MSSQL_PID
+            value: "Developer"
+          - name: ACCEPT_EULA
+            value: "Y"
+          - name: MSSQL_SA_PASSWORD
+            value: MyPass@word
+          - name: MSSQL_USER
+            value: SA
+          volumeMounts:
+          - mountPath: /var/opt/mssql/data
+            name: mssqldb
+      volumes:
+      - name: mssqldb
+        persistentVolumeClaim:
+          claimName: mssql-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mssql-makers-clusterip-service
+spec:
+  type: ClusterIP
+  selector:
+    app: mssql
+  ports:
+    - name: mssql
+      protocol: TCP
+      port: 1433
+      targetPort: 1433
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mssql-makers-loadbalancer
+spec:
+  type: LoadBalancer
+  selector:
+    app: mssql
+  ports:
+  - protocol: TCP
+    port: 1433
+    targetPort: 1433


### PR DESCRIPTION
SQL Server does  not work on the new Macbook:

The original SQL Server for Linux image has not yet been ported to the ARM64 architecture, which is what the  M1 Mac uses.

Therefore, it is not possible to use the below image: mcr.microsoft.com/mssql/server

Instead, I need to use:
mcr.microsoft.com/azure-sql-edge

At present the password is exposed. Need to retry by storing the password as a secret.